### PR TITLE
Fix OSX relative path bug

### DIFF
--- a/smell-test
+++ b/smell-test
@@ -8,6 +8,7 @@ import time
 import json
 from sys import exit
 
+
 # look for the Debian package name
 try:
     import scapy3k as scapy
@@ -54,7 +55,10 @@ def cache_path():
         # thie function checks that $XDG_CACHE_HOME exists and returns the path
         path = xdg.BaseDirectory.save_cache_path('smell-test/')
     elif this_os == 'Darwin':
-        path = '~/Library/Application Support/smell-test/'
+        # resolve user's home directory
+        home = os.path.expanduser('~')
+        path = home + '/Library/Application Support/smell-test/'
+        print(path)
         if not os.path.exists(path): 
             try:
                 os.makedirs(path)
@@ -170,9 +174,9 @@ def select_DNS(pkt):
     except Exception as e:
         print(e)
 
-cache_path()
 print ('[**] Beginning "Smell Test"')
 try:
     sniff(iface=interface, filter=filter_bpf, store=0,  prn=select_DNS)
 except OSError as e:
+    # note: this works on Linux but OS X segfaults when the interface is wrong lmao
     print('[-] ERROR: "{}". (Make sure `interface` matches your network interface)'.format(e))


### PR DESCRIPTION
Stop OSX creating `./~/$cache_path` instead of resolving the ~