### PR TITLE
Add logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-*.json
-results/
-
+logs/*
 # Boilerplate python below
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,0 +1,46 @@
+---
+version: 1
+disable_existing_loggers: True
+formatters:
+    simple:
+        format: "%(relativeCreated)6d,%(threadName)s - [%(levelname)s] - %(message)s"
+    detailed:
+        format: "%(asctime)s: %(relativeCreated)6d,%(threadName)s - [%(levelname)s] - %(message)s"
+handlers:
+    console:
+        class: logging.StreamHandler
+        level: ERROR
+        formatter: simple
+        stream: ext://sys.stdout
+
+    info_file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: INFO
+        formatter: simple
+        filename: logs/info.log
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+        encoding: utf8
+
+    error_file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: ERROR
+        formatter: detailed
+        filename: logs/errors.log
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+        encoding: utf8
+
+    debug_file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: DEBUG
+        formatter: detailed
+        filename: logs/debug.log
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+        encoding: utf8
+
+root:
+    level: DEBUG
+    handlers: [console, info_file_handler, debug_file_handler, error_file_handler]
+...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 scapy-python3
 pyxdg
 click
+pyyaml
 pytest
 pylint

--- a/smell_test.py
+++ b/smell_test.py
@@ -44,8 +44,8 @@ def setup_logging(
     if value:
         path = value
     if os.path.exists(path):
-        with open(path, 'rt') as f:
-            config = yaml.safe_load(f.read())
+        with open(path, 'rt') as yaml_config_file:
+            config = yaml.safe_load(yaml_config_file.read())
         logging.config.dictConfig(config)
     else:
         logging.basicConfig(level=default_level)


### PR DESCRIPTION
This PR uses python's built-in logging to replace print statements (and in fact all output from the script). It should now run silently, except for errors.

Logs are stored in `logs` as `info.log`, `debug.log` and `error.log`. The way this works is:

* `info.log` will contain logs of type `INFO` and `ERROR` and has **no timestamps**

* `debug.log` will contains logs of type `INFO`, `DEBUG` and `ERROR` and **has timestamps**.

* `error.log` will contain logs of only type `ERROR` and **has timestamps**.

Users can now simply do something like `grep "VULNERABLE" logs/info.log` to get a list of all vulnerable hosts and the location of the JSON files containing the details of those vulnerabilities.